### PR TITLE
Exception name too long prevents upload

### DIFF
--- a/countlyCommon/countlyCommon/CountlyBase.cs
+++ b/countlyCommon/countlyCommon/CountlyBase.cs
@@ -911,7 +911,7 @@ namespace CountlySDK.CountlyCommon
             Dictionary<string, string> segmentation = UtilityHelper.RemoveExtraSegments(customInfo, config.MaxSegmentationValues);
             segmentation = UtilityHelper.FixSegmentKeysAndValues(segmentation, config.MaxKeyLength, config.MaxValueSize);
 
-            ExceptionEvent eEvent = new ExceptionEvent(error, UtilityHelper.ManipulateStackTrace(stackTrace, Configuration.MaxStackTraceLinesPerThread, Configuration.MaxStackTraceLineLength) ?? string.Empty, unhandled, string.Join("\n", CrashBreadcrumbs.ToArray()), run, AppVersion, segmentation, DeviceData);
+            ExceptionEvent eEvent = new ExceptionEvent(error.Substring(0, Math.Min(error.Length - 1, 2000)), UtilityHelper.ManipulateStackTrace(stackTrace, Configuration.MaxStackTraceLinesPerThread, Configuration.MaxStackTraceLineLength) ?? string.Empty, unhandled, string.Join("\n", CrashBreadcrumbs.ToArray()), run, AppVersion, segmentation, DeviceData);
 
             if (!unhandled) {
                 bool saveSuccess = false;
@@ -960,6 +960,7 @@ namespace CountlySDK.CountlyCommon
                 ExceptionEvent exEvent;//the exception event that will be uploaded
                 lock (sync) {
                     exEvent = Exceptions[0];
+
                 }
 
                 //do the exception upload

--- a/countlyCommon/countlyCommon/CountlyBase.cs
+++ b/countlyCommon/countlyCommon/CountlyBase.cs
@@ -960,7 +960,6 @@ namespace CountlySDK.CountlyCommon
                 ExceptionEvent exEvent;//the exception event that will be uploaded
                 lock (sync) {
                     exEvent = Exceptions[0];
-
                 }
 
                 //do the exception upload

--- a/countlyCommon/countlyCommon/Server/ApiBase.cs
+++ b/countlyCommon/countlyCommon/Server/ApiBase.cs
@@ -43,6 +43,7 @@ namespace CountlySDK.CountlyCommon.Server
 
         public async Task<RequestResult> SendException(string serverUrl, RequestHelper requestHelper, int rr, ExceptionEvent exception)
         {
+            exception.Name = exception.Name.Substring(0, Math.Min(exception.Name.Length-1, 2000));
             string exceptionJson = UtilityHelper.EncodeDataForURL(RequestHelper.Json(exception));
             return await Call(string.Format("{0}{1}&crash={2}&rr={3}", serverUrl, await requestHelper.BuildRequest(), exceptionJson, rr));
         }


### PR DESCRIPTION
We identified an issue where exception reports could be generated with excessively long names that included the entire stack trace. This bypassed the intended length limits for exception names, resulting in reports that exceeded the server’s ~65,000 character limit. When this occurred, an exception was thrown during the attempt to send the report to the server.

Compounding the problem, the problematic report, being the first in the queue, prevented any subsequent exception reports from being sent, as there was no mechanism to skip or remove it from the queue. Furthermore, the failure to send due to the URI string being too long was itself not reported to the server. This made it impossible to detect when non-development devices were unable to send exception reports because one report exceeded the length limit.

As a temporary mitigation, we introduced a simple restriction on the maximum length of the exception name, applied both when creating the report and when sending it. This ensures that oversized reports are either avoided or cleared from existing backlogs, allowing affected devices to resume sending exception reports as expected.

For reference, [here is an example report](https://github.com/user-attachments/files/21165421/long.name.exception.report.json) that triggered this issue.